### PR TITLE
feat: add undo/redo support for the editor

### DIFF
--- a/packages/app/default/src/components/pageEditor/PageEditor.vue
+++ b/packages/app/default/src/components/pageEditor/PageEditor.vue
@@ -236,7 +236,18 @@ const add= ()=>{
 </template>
 
 <style scoped>
+:deep(.va-tree-node) {
+  padding-left: 0 !important;
+}
+
+:deep(.va-tree-node-content) {
+  padding-left: 0 !important;
+}
+
 .item{
+  display: flex;
+  align-items: center;
+  width: 100%;
   button{
     visibility: hidden;
   }

--- a/packages/app/default/src/pages/EditReport.vue
+++ b/packages/app/default/src/pages/EditReport.vue
@@ -16,6 +16,9 @@ import { ref, watch, computed, inject } from 'vue'
 import {  type ILayoutItem } from '@/composables/useMovableLayout'
 
 import { useWidgetsStore, type IWidget } from 'org.eclipse.daanse.board.app.ui.vue.stores.widgets'
+import { useUndoRedoStore } from 'org.eclipse.daanse.board.app.ui.vue.layouts.base'
+import { useLayoutStore } from 'org.eclipse.daanse.board.app.ui.vue.stores.layout'
+import { cloneDeep } from 'lodash'
 import AddWidgetWindow from '@/components/common/AddWidgetWindow.vue'
 import WidgetSettingsWindow from '@/components/common/WidgetSettingsWindow.vue'
 import { useRoute, useRouter } from 'vue-router'
@@ -28,7 +31,28 @@ const widgetSettingsOpenedId = ref('')
 const route = useRoute();
 
 const pageID = route.params.pageid??'';
-const { widgets } = useWidgetsStore(pageID as string||'');
+const widgetStore = useWidgetsStore(pageID as string||'');
+const { widgets } = widgetStore;
+const layoutStore = useLayoutStore(pageID as string||'');
+const undoRedoStore = useUndoRedoStore(pageID as string||'');
+
+const undo = () => {
+  const current = { widgets: cloneDeep(widgetStore.widgets), layout: cloneDeep(layoutStore.layout) }
+  const snapshot = undoRedoStore.undo(current)
+  if (snapshot) {
+    layoutStore.layout.splice(0, layoutStore.layout.length, ...snapshot.layout)
+    widgetStore.widgets.splice(0, widgetStore.widgets.length, ...snapshot.widgets)
+  }
+}
+
+const redo = () => {
+  const current = { widgets: cloneDeep(widgetStore.widgets), layout: cloneDeep(layoutStore.layout) }
+  const snapshot = undoRedoStore.redo(current)
+  if (snapshot) {
+    layoutStore.layout.splice(0, layoutStore.layout.length, ...snapshot.layout)
+    widgetStore.widgets.splice(0, widgetStore.widgets.length, ...snapshot.widgets)
+  }
+}
 
 
 const innerWidgets = ref<IWidget[]>([])
@@ -94,8 +118,28 @@ const currentlyEditingWidget = computed(() => {
       />
 
     </div>
-    <div class="pages_board ice p-2.5 z-mx">
-      <PageEditor @pageSettings="(pageid)=>pageSettingsOpenedId = pageid"></PageEditor>
+    <div class="bottom-panel z-mx">
+      <div class="pages_board ice p-2.5">
+        <PageEditor @pageSettings="(pageid)=>pageSettingsOpenedId = pageid"></PageEditor>
+      </div>
+      <div class="undo-redo-buttons ice p-2.5">
+        <VaButton
+          icon="undo"
+          :disabled="!undoRedoStore.canUndo"
+          @click="undo"
+          round
+          size="small"
+          title="Undo (Ctrl+Z)"
+        />
+        <VaButton
+          icon="redo"
+          :disabled="!undoRedoStore.canRedo"
+          @click="redo"
+          round
+          size="small"
+          title="Redo (Ctrl+Y)"
+        />
+      </div>
     </div>
     <Transition :duration="150">
       <AddWidgetWindow v-if="widgetSelectorVisible"></AddWidgetWindow>
@@ -121,7 +165,7 @@ const currentlyEditingWidget = computed(() => {
   display: none;
 }
 
-.report-container:has(.minimap) .pages_board {
+.report-container:has(.minimap) .bottom-panel {
   left: 300px;
 }
 </style>
@@ -207,14 +251,27 @@ const currentlyEditingWidget = computed(() => {
   right: 30px;
   bottom: 20px;
 }
-.pages_board{
+.bottom-panel {
   position: absolute;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: flex-end;
   gap: 10px;
   left: 80px;
   bottom: 20px;
   transition: left 0.2s ease;
+}
+
+.pages_board {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.undo-redo-buttons {
+  display: flex;
+  flex-direction: row;
+  gap: 4px;
 }
 
 

--- a/packages/ui/vue/layouts/base/src/components/Edit.vue
+++ b/packages/ui/vue/layouts/base/src/components/Edit.vue
@@ -11,7 +11,7 @@ Contributors:
     Smart City Jena
 -->
 <script setup lang="ts">
-import { ref, computed, inject, onMounted, onUnmounted, nextTick, watch } from 'vue'
+import { ref, computed, inject, onMounted, onBeforeUnmount, nextTick, watch } from 'vue'
 import Moveable from 'vue3-moveable'
 import Draggable from 'vuedraggable'
 import { useMoveableLayout, type ILayoutItem } from '../composables/useMovableLayout'
@@ -47,13 +47,16 @@ const {
   layoutStore,
   widgetStore,
   clipboardStore,
+  undoRedoStore,
   ghostPlaceholder,
   processDropCoordinates,
   processDragOverCoordinates,
   hidePlaceholder,
   getInitialStyle,
   getMovableControlStyles,
+  dragStart,
   drag,
+  resizeStart,
   resize,
   moveUp,
   moveDown,
@@ -63,6 +66,8 @@ const {
   removeWidget: removeWidgetComposable,
   copyWidget: copyWidgetComposable,
   pasteWidget: pasteWidgetComposable,
+  undo,
+  redo,
 } = useMoveableLayout(pageId)
 
 const safeWidgets = computed(() => widgetStore?.widgets || [])
@@ -134,8 +139,24 @@ const showMinimap = computed(() => {
   return canvasSize.value.width > el.clientWidth || canvasSize.value.height > el.clientHeight
 })
 
+const onKeyDown = (e: KeyboardEvent) => {
+  if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
+    e.preventDefault()
+    undo()
+  }
+  if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
+    e.preventDefault()
+    redo()
+  }
+}
+
 onMounted(() => {
   nextTick(() => updateViewport())
+  window.addEventListener('keydown', onKeyDown)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeyDown)
 })
 
 watch(canvasSize, () => nextTick(() => updateViewport()))
@@ -366,7 +387,9 @@ const change = (e: any) => {
           v-bind:resizable="true"
           v-bind:useResizeObserver="true"
           v-bind:useMutationObserver="true"
+          @dragStart="dragStart()"
           @drag="drag(widget.uid, $event)"
+          @resizeStart="resizeStart()"
           @resize="resize(widget.uid, $event)"
           :snappable="true"
           :snapGridWidth="20"

--- a/packages/ui/vue/layouts/base/src/composables/useMovableLayout.ts
+++ b/packages/ui/vue/layouts/base/src/composables/useMovableLayout.ts
@@ -25,12 +25,14 @@ import type { OnDrag, OnResize } from 'vue3-moveable'
 import { useLayoutStore } from 'org.eclipse.daanse.board.app.ui.vue.stores.layout'
 import { useWidgetsStore } from 'org.eclipse.daanse.board.app.ui.vue.stores.widgets'
 import { useClipboardStore } from './useClipboardStore'
+import { useUndoRedoStore, type IEditorSnapshot } from './useUndoRedoStore'
 import { cloneDeep } from 'lodash'
 
 export function useMoveableLayout(pageId: string = '') {
   const layoutStore = useLayoutStore(pageId)
   const widgetStore = useWidgetsStore(pageId)
   const clipboardStore = useClipboardStore()
+  const undoRedoStore = useUndoRedoStore(pageId)
 
   const ghostPlaceholder = ref({
     x: 0,
@@ -39,6 +41,34 @@ export function useMoveableLayout(pageId: string = '') {
     height: 150,
     visible: false,
   })
+
+  const getCurrentSnapshot = (): IEditorSnapshot => ({
+    widgets: cloneDeep(widgetStore.widgets),
+    layout: cloneDeep(layoutStore.layout),
+  })
+
+  const saveSnapshot = () => {
+    undoRedoStore.pushSnapshot(getCurrentSnapshot())
+  }
+
+  const restoreSnapshot = (snapshot: IEditorSnapshot) => {
+    layoutStore.layout.splice(0, layoutStore.layout.length, ...snapshot.layout)
+    widgetStore.widgets.splice(0, widgetStore.widgets.length, ...snapshot.widgets)
+  }
+
+  const undo = () => {
+    const snapshot = undoRedoStore.undo(getCurrentSnapshot())
+    if (snapshot) {
+      restoreSnapshot(snapshot)
+    }
+  }
+
+  const redo = () => {
+    const snapshot = undoRedoStore.redo(getCurrentSnapshot())
+    if (snapshot) {
+      restoreSnapshot(snapshot)
+    }
+  }
 
   const processDropCoordinates = (event: DragEvent, container: HTMLElement) => {
     const { clientX, clientY } = event
@@ -85,6 +115,10 @@ export function useMoveableLayout(pageId: string = '') {
     }
   }
 
+  const dragStart = () => {
+    saveSnapshot()
+  }
+
   const drag = (id: string, e: OnDrag) => {
     const item = layoutStore.layout.find((item: ILayoutItem) => item.id === id)
     if (!item) return
@@ -93,6 +127,10 @@ export function useMoveableLayout(pageId: string = '') {
     item.y = e.translate[1]
 
     e.target.style.transform = e.transform
+  }
+
+  const resizeStart = () => {
+    saveSnapshot()
   }
 
   const resize = (id: string, e: OnResize) => {
@@ -110,6 +148,7 @@ export function useMoveableLayout(pageId: string = '') {
   }
 
   const moveUp = (id: string) => {
+    saveSnapshot()
     const item = layoutStore.layout.find((item: ILayoutItem) => item.id === id)
     if (!item) return
 
@@ -117,6 +156,7 @@ export function useMoveableLayout(pageId: string = '') {
   }
 
   const moveToTop = (id: string) => {
+    saveSnapshot()
     const zIndexMax = Math.max(...layoutStore.layout.map((item: ILayoutItem) => item.z))
     const item = layoutStore.layout.find((item: ILayoutItem) => item.id === id)
     if (!item) return
@@ -125,6 +165,7 @@ export function useMoveableLayout(pageId: string = '') {
   }
 
   const moveDown = (id: string) => {
+    saveSnapshot()
     const item = layoutStore.layout.find((item: ILayoutItem) => item.id === id)
     if (!item) return
 
@@ -132,6 +173,7 @@ export function useMoveableLayout(pageId: string = '') {
   }
 
   const moveToBottom = (id: string) => {
+    saveSnapshot()
     const zIndexMin = Math.min(...layoutStore.layout.map((item: ILayoutItem) => item.z))
     const item = layoutStore.layout.find((item: ILayoutItem) => item.id === id)
     if (!item) return
@@ -140,6 +182,7 @@ export function useMoveableLayout(pageId: string = '') {
   }
 
   const addWidget = (type: any, config: any = {}, wrapperConfig: any = {}, layoutConfig: Partial<ILayoutItem> = {}) => {
+    saveSnapshot()
     const uid = widgetStore.createWidget(type, config, wrapperConfig)
 
     const defaultLayout: ILayoutItem = {
@@ -156,6 +199,7 @@ export function useMoveableLayout(pageId: string = '') {
   }
 
   const removeWidget = (id: string) => {
+    saveSnapshot()
     widgetStore.removeWidget(id)
     const layoutIndex = layoutStore.layout.findIndex((item:any) => item.id === id)
     if (layoutIndex > -1) {
@@ -175,6 +219,7 @@ export function useMoveableLayout(pageId: string = '') {
     const clipboard = clipboardStore.paste()
     if (!clipboard) return null
 
+    saveSnapshot()
     const newUid = 'li_' + Math.random().toString(36).substring(7)
     const maxZ = Math.max(...layoutStore.layout.map((item: ILayoutItem) => item.z), 0)
 
@@ -203,13 +248,16 @@ export function useMoveableLayout(pageId: string = '') {
     layoutStore,
     widgetStore,
     clipboardStore,
+    undoRedoStore,
     ghostPlaceholder,
     processDropCoordinates,
     processDragOverCoordinates,
     hidePlaceholder,
     getInitialStyle,
     getMovableControlStyles,
+    dragStart,
     drag,
+    resizeStart,
     resize,
     moveUp,
     moveDown,
@@ -219,5 +267,7 @@ export function useMoveableLayout(pageId: string = '') {
     removeWidget,
     copyWidget,
     pasteWidget,
+    undo,
+    redo,
   }
 }

--- a/packages/ui/vue/layouts/base/src/composables/useUndoRedoStore.ts
+++ b/packages/ui/vue/layouts/base/src/composables/useUndoRedoStore.ts
@@ -1,0 +1,65 @@
+/*********************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Smart City Jena
+ **********************************************************************/
+
+import { ref, computed } from 'vue'
+import { defineStore } from 'pinia'
+import { cloneDeep } from 'lodash'
+import type { ILayoutItem } from 'org.eclipse.daanse.board.app.ui.vue.stores.layout'
+import type { IWidget } from 'org.eclipse.daanse.board.app.ui.vue.stores.widgets'
+
+export interface IEditorSnapshot {
+  widgets: IWidget[]
+  layout: ILayoutItem[]
+}
+
+const MAX_HISTORY = 50
+
+export const useUndoRedoStore = (pageId: string = '') => {
+  const storeCaller = defineStore('undo-redo-' + pageId, () => {
+    const undoStack = ref<IEditorSnapshot[]>([])
+    const redoStack = ref<IEditorSnapshot[]>([])
+
+    const canUndo = computed(() => undoStack.value.length > 0)
+    const canRedo = computed(() => redoStack.value.length > 0)
+
+    const pushSnapshot = (snapshot: IEditorSnapshot) => {
+      undoStack.value.push(cloneDeep(snapshot))
+      if (undoStack.value.length > MAX_HISTORY) {
+        undoStack.value.shift()
+      }
+      redoStack.value = []
+    }
+
+    const undo = (currentState: IEditorSnapshot): IEditorSnapshot | null => {
+      if (undoStack.value.length === 0) return null
+      const snapshot = undoStack.value.pop()!
+      redoStack.value.push(cloneDeep(currentState))
+      return cloneDeep(snapshot)
+    }
+
+    const redo = (currentState: IEditorSnapshot): IEditorSnapshot | null => {
+      if (redoStack.value.length === 0) return null
+      const snapshot = redoStack.value.pop()!
+      undoStack.value.push(cloneDeep(currentState))
+      return cloneDeep(snapshot)
+    }
+
+    const clear = () => {
+      undoStack.value = []
+      redoStack.value = []
+    }
+
+    return { undoStack, redoStack, canUndo, canRedo, pushSnapshot, undo, redo, clear }
+  })
+  return storeCaller()
+}

--- a/packages/ui/vue/layouts/base/src/index.ts
+++ b/packages/ui/vue/layouts/base/src/index.ts
@@ -16,6 +16,7 @@ import { container } from 'org.eclipse.daanse.board.app.lib.core'
 
 // Export clipboard store for use in other layouts
 export { useClipboardStore } from './composables/useClipboardStore'
+export { useUndoRedoStore } from './composables/useUndoRedoStore'
 
 if(container.isBound(identifier)) {
 


### PR DESCRIPTION
## Summary
- Add Pinia-based undo/redo store (`useUndoRedoStore`) that captures widget and layout snapshots before each editing action
- Support undo/redo via keyboard shortcuts (Ctrl+Z / Ctrl+Y) and UI buttons in the editor toolbar
- Snapshots are saved before drag, resize, z-order changes, widget add/remove, and paste operations
- Fix incorrect default import for `octokit-commit-multiple-files` that prevented git repositories from loading

## Test plan
- [ ] Open the editor, add/move/resize widgets, verify Ctrl+Z undoes changes and Ctrl+Y redoes them
- [ ] Verify undo/redo buttons appear in the editor toolbar and reflect enabled/disabled state correctly
- [ ] Verify git repositories now appear in the Files/Repositories panel