### PR TITLE
Map: scalable icons, clustering & performance; chart per-series value formula

### DIFF
--- a/packages/app/default/src/pages/SaveLoad.vue
+++ b/packages/app/default/src/pages/SaveLoad.vue
@@ -148,7 +148,9 @@ watch(upload, (newVal) => {
       save_Ename.value = name.split('.')[0]
       isOpenedName.value = true
       content.value = result.target?.result ?? undefined
-
+      // Actually load the uploaded board — previously the content was read but
+      // never consumed, so "Upload file" appeared to do nothing.
+      if (content.value !== undefined) loadData(content.value)
     })
     reader.readAsText(newVal[0])
   }
@@ -214,7 +216,12 @@ const loadData = (content: any) => {
     // Handle both string and object content
     if (typeof content === 'string') {
       data = JSON.parse(content)
-      if(Array.isArray(data)){ //false format serialized be flatted ?
+      // Downloaded boards are double-encoded: a flatted string that JSON.stringify
+      // wrapped again. JSON.parse then yields the inner flatted string, which must
+      // be flatted-parsed. Repo-stored boards yield a flatted array directly.
+      if (typeof data === 'string') {
+        data = parse(data)
+      } else if (Array.isArray(data)) { //false format serialized be flatted ?
         data = parse(content)
       }
     } else {
@@ -247,20 +254,20 @@ const loadData = (content: any) => {
     }
 
     if (data.conections) conections.connections = data.conections
-    for(const connection of data.conections) {
+    for(const connection of (data.conections || [])) {
       if(connectionRepository)(connectionRepository as ConnectionRepository)
         .registerConnection(connection.uid, connection.type, connection.config)
     }
 
 
 
-    for(const datasource of data.datasources) {
+    for(const datasource of (data.datasources || [])) {
       if(dsRepository && !['chart','datatable'].includes(datasource.type)){
         (dsRepository as DatasourceRepository)
           .registerDatasource(datasource.uid, datasource.type, datasource.config)
       }
     }
-    for(const datasource of data.datasources) {
+    for(const datasource of (data.datasources || [])) {
       if(dsRepository && ['chart','datatable'].includes(datasource.type)){
         (dsRepository as DatasourceRepository)
           .registerDatasource(datasource.uid, datasource.type, datasource.config)

--- a/packages/lib/datasource/ogcsta/src/classes/OgcSta.ts
+++ b/packages/lib/datasource/ogcsta/src/classes/OgcSta.ts
@@ -373,19 +373,42 @@ export class OgcStaStore extends BaseDatasource implements OgcStaStoreI {
         return isolatedData as T
       }
 
-      // Normal request: add to cache
+      // Normal request: merge into cache. Deduplicate by iotId — every
+      // filter/refresh cycle used to blindly concat the full result set,
+      // multiplying every location/thing/datastream in the cache (6× after
+      // six cycles) and inflating marker counts, cluster numbers and loop
+      // work everywhere downstream. Existing entries win so observations
+      // already merged onto cached objects are kept.
+      const mergeById = <T>(existing: T[] | undefined, incoming: T[]): T[] => {
+        const current = existing ?? []
+        if (current.length === 0) return current.concat(incoming)
+        const seen = new Set<any>()
+        for (const e of current) {
+          const id = (e as any)?.iotId ?? (e as any)?.['@iot.id']
+          if (id != null) seen.add(id)
+        }
+        const additions = incoming.filter(item => {
+          const id = (item as any)?.iotId ?? (item as any)?.['@iot.id']
+          if (id == null) return true
+          if (seen.has(id)) return false
+          seen.add(id)
+          return true
+        })
+        return additions.length ? current.concat(additions) : current
+      }
+
       for (const result of results) {
         if (result.datastreams) {
-          this.resultMap.datastreams = this.resultMap.datastreams?.concat(result.datastreams)
+          this.resultMap.datastreams = mergeById(this.resultMap.datastreams, result.datastreams)
         }
         if (result.things) {
-          this.resultMap.things = this.resultMap.things?.concat(result.things)
+          this.resultMap.things = mergeById(this.resultMap.things, result.things)
         }
         if (result.observations) {
           this.resultMap.observations = this.resultMap.observations?.concat(result.observations as Observation[])
         }
         if (result.locations) {
-          this.resultMap.locations = this.resultMap.locations?.concat(result.locations)
+          this.resultMap.locations = mergeById(this.resultMap.locations, result.locations)
         }
       }
 

--- a/packages/ui/vue/widget/chart/src/ChartWidget.vue
+++ b/packages/ui/vue/widget/chart/src/ChartWidget.vue
@@ -258,6 +258,30 @@ const chartData = computed(() => {
         }
       }
 
+      // Apply optional per-series value conversion formula (e.g. °F → °C).
+      // The expression sees the raw data point as `value`; compiled once per
+      // dataset, invalid formulas leave the data untouched.
+      const valueFormula = (seriesSettings?.valueFormula as any)?.value
+      if (typeof valueFormula === 'string' && valueFormula.trim() && Array.isArray(result.data)) {
+        try {
+          const convert = new Function('value', `return (${valueFormula})`) as (v: number) => number
+          result.data = result.data.map((point: any) => {
+            if (point == null) return point
+            if (typeof point === 'number') {
+              const converted = convert(point)
+              return Number.isFinite(converted) ? converted : point
+            }
+            if (typeof point === 'object' && point.y != null) {
+              const converted = convert(Number(point.y))
+              return Number.isFinite(converted) ? { ...point, y: converted } : point
+            }
+            return point
+          })
+        } catch (e) {
+          console.warn('Invalid series value formula:', valueFormula, e)
+        }
+      }
+
       return result
     })
   }

--- a/packages/ui/vue/widget/chart/src/ChartWidgetSettings.vue
+++ b/packages/ui/vue/widget/chart/src/ChartWidgetSettings.vue
@@ -212,6 +212,9 @@ const addSeriesSettings = () => {
   newSettings.pointColor = new VariableWrapper<string>('')
   newSettings.pointSize = new VariableWrapper<number>(3)
 
+  // Initialize optional value conversion formula
+  newSettings.valueFormula = new VariableWrapper<string>('')
+
   widgetSettings.value.seriesSettings.push(newSettings)
 }
 
@@ -269,6 +272,9 @@ onMounted(() => {
     if (!series.pointSize) {
       series.pointSize = new VariableWrapper<number>(3)
     }
+    if (!series.valueFormula) {
+      series.valueFormula = new VariableWrapper<string>('')
+    }
   })
 })
 </script>
@@ -323,6 +329,23 @@ onMounted(() => {
                 :model-value="value"
                 @input="change"
                 placeholder="e.g., Temperature, Humidity, Pressure..."
+              />
+            </template>
+          </VariableInput>
+
+          <VariableInput
+            v-if="series.valueFormula !== undefined"
+            label="Value formula (optional)"
+            v-model="(series.valueFormula as unknown as VariableWrapper<string>)"
+            style="margin-bottom: 12px;"
+          >
+            <template #default="{ value, change }">
+              <va-input
+                label="Value formula (optional)"
+                :model-value="value"
+                @input="change"
+                placeholder="e.g. (value - 32) * 5 / 9"
+                messages="JavaScript expression applied to each data point; the raw value is available as 'value'."
               />
             </template>
           </VariableInput>

--- a/packages/ui/vue/widget/chart/src/gen/SeriesSettings.ts
+++ b/packages/ui/vue/widget/chart/src/gen/SeriesSettings.ts
@@ -42,4 +42,7 @@ export class SeriesSettings {
   @Reference('VariableWrapper') showPoints: VariableWrapper<boolean> = new VariableWrapper<boolean>();
   @Reference('VariableWrapper') pointColor: VariableWrapper<string> = new VariableWrapper<string>();
   @Reference('VariableWrapper') pointSize: VariableWrapper<number> = new VariableWrapper<number>();
+
+  @Documentation("Optional JavaScript expression applied to every data point of this series, with the raw value available as 'value'. Example: (value - 32) * 5 / 9 converts Fahrenheit to Celsius.")
+  @Reference('VariableWrapper') valueFormula: VariableWrapper<string> = new VariableWrapper<string>();
 }

--- a/packages/ui/vue/widget/map/src/MapsWidget.vue
+++ b/packages/ui/vue/widget/map/src/MapsWidget.vue
@@ -56,6 +56,7 @@ const route = useRoute()
 const pageId = (route.params.pageid as string) || ''
 const config = defineModel<MapSettings>('configv', { required: true});
 const map = ref(null)
+const currentZoom = ref(config.value?.zoom ?? 14)
 const defaultConfig = new MapSettings()
 
 // Get EventActionsRegistry
@@ -659,6 +660,9 @@ const maploaded = () => {
     })
     leaflet.on('moveend', () => {
       isMapInteracting = false
+    })
+    leaflet.on('zoomend', () => {
+      currentZoom.value = leaflet.getZoom()
     })
   }
 }
@@ -1357,6 +1361,7 @@ onUnmounted(() => {
           :selection-highlight-color="config.selectionHighlightColor ?? '#ff0000'"
           :tooltip-thing-id="tooltipThingId"
           :tooltip-content="tooltipContent"
+          :current-zoom="currentZoom"
         />
       </template>
 

--- a/packages/ui/vue/widget/map/src/MapsWidget.vue
+++ b/packages/ui/vue/widget/map/src/MapsWidget.vue
@@ -1362,6 +1362,7 @@ onUnmounted(() => {
           :tooltip-thing-id="tooltipThingId"
           :tooltip-content="tooltipContent"
           :current-zoom="currentZoom"
+          :cluster-global="config.clusterGlobal ?? false"
         />
       </template>
 

--- a/packages/ui/vue/widget/map/src/MapsWidgetSettings.vue
+++ b/packages/ui/vue/widget/map/src/MapsWidgetSettings.vue
@@ -649,6 +649,14 @@ const assignDatasourceToLayer = (layer: any, dsId: string) => {
           label="Map fixed"
         />
 
+        <va-checkbox
+          v-model="widgetSettings.clusterGlobal"
+          label="Cluster markers across renderers"
+        />
+        <p class="hint-text">
+          Combine markers of all renderers into shared clusters instead of one cluster set per renderer.
+        </p>
+
         <va-color-input
           v-model="widgetSettings.selectionHighlightColor"
           label="Selection Highlight Color"

--- a/packages/ui/vue/widget/map/src/Settings.ts
+++ b/packages/ui/vue/widget/map/src/Settings.ts
@@ -28,6 +28,7 @@ export interface IMapSettings {
   fixed:boolean,
   selectionHighlightColor?: string,
   selectedThingId?: string | null
+  clusterGlobal?: boolean,
 }
 
 export interface LayerI {

--- a/packages/ui/vue/widget/map/src/api/Renderer.ts
+++ b/packages/ui/vue/widget/map/src/api/Renderer.ts
@@ -37,7 +37,16 @@ export interface IPointAndAreaSettings {
   point: IIconSettings
   pointPin: IPointPin
   area: IMapProps,
-  label?: any
+  label?: any,
+  iconMinZoom?: number,
+  iconScaleWithZoom?: boolean,
+  iconFullSizeZoom?: number,
+  labelMinZoom?: number,
+  labelScaleWithZoom?: boolean,
+  labelFullSizeZoom?: number,
+  clusterEnabled?: boolean,
+  clusterBelowZoom?: number,
+  clusterRadius?: number,
 }
 
 export interface IDSRenderer {

--- a/packages/ui/vue/widget/map/src/components/MapMarker.vue
+++ b/packages/ui/vue/widget/map/src/components/MapMarker.vue
@@ -23,6 +23,7 @@ interface MapMarkerProps {
   isSolid?: boolean
   isSelected?: boolean
   selectionColor?: string
+  scale?: number
 }
 
 const props = withDefaults(defineProps<MapMarkerProps>(), {
@@ -30,7 +31,8 @@ const props = withDefaults(defineProps<MapMarkerProps>(), {
   isSolid: false,
   imageSize: 32,
   isSelected: false,
-  selectionColor: '#ff0000'
+  selectionColor: '#ff0000',
+  scale: 1,
 })
 </script>
 
@@ -38,7 +40,8 @@ const props = withDefaults(defineProps<MapMarkerProps>(), {
   <template v-if="renderAs === 'icon'">
     <div
       :style="{
-        background: isSelected ? selectionColor : backgroundColor
+        background: isSelected ? selectionColor : backgroundColor,
+        transform: scale !== 1 ? `rotate(-45deg) scale(${scale})` : undefined,
       }"
       :class="['pin', 'icon', { round: isRound, solid: isSolid }]"
     >
@@ -57,7 +60,8 @@ const props = withDefaults(defineProps<MapMarkerProps>(), {
   <template v-if="renderAs === 'prop'">
     <div
       :style="{
-        background: isSelected ? selectionColor : backgroundColor
+        background: isSelected ? selectionColor : backgroundColor,
+        transform: scale !== 1 ? `scale(${scale})` : undefined,
       }"
       :class="['pin', 'contain', 'marker', { round: isRound, solid: isSolid }]"
     >
@@ -78,7 +82,8 @@ const props = withDefaults(defineProps<MapMarkerProps>(), {
         height: `${imageSize}px`,
         background: isSelected ? selectionColor : undefined,
         borderRadius: isSelected ? '50%' : undefined,
-        padding: isSelected ? '4px' : undefined
+        padding: isSelected ? '4px' : undefined,
+        transform: scale !== 1 ? `scale(${scale})` : undefined,
       }"
     >
       <img

--- a/packages/ui/vue/widget/map/src/components/OGCSTALayer.vue
+++ b/packages/ui/vue/widget/map/src/components/OGCSTALayer.vue
@@ -9,7 +9,7 @@ Contributors: Smart City Jena
 
 -->
 <script lang="ts" setup>
-import { ref, computed, onErrorCaptured, type Ref } from 'vue'
+import { ref, computed, onErrorCaptured, toRaw, type Ref } from 'vue'
 import { LGeoJson, LMarker, LIcon, LTooltip } from '@vue-leaflet/vue-leaflet'
 import { type BoxedDatastream } from 'org.eclipse.daanse.board.app.lib.datasource.ogcsta'
 import L from 'leaflet'
@@ -44,6 +44,7 @@ interface OGCSTALayerProps {
   tooltipThingId?: string | null
   tooltipContent?: string | null
   currentZoom?: number
+  clusterGlobal?: boolean
 }
 
 const props = defineProps<OGCSTALayerProps>()
@@ -93,9 +94,15 @@ const matchedItems = computed(() => {
     for (const location of props.locations) {
       const locationThings = location.things ?? []
       for (const thing of locationThings) {
-        if (!props.compareThing(thing, renderer)) continue
+        // Condition matching (compareThing/compareDatastream → resolveObj) reads
+        // many properties per datastream. Doing that through Vue's reactive
+        // proxies dominated zoom/pan profiles, so match on the raw objects.
+        // Reactivity is kept by explicitly touching `observations` below —
+        // the store re-assigns it when new observations are merged.
+        const rawThing = toRaw(thing)
+        if (!props.compareThing(rawThing, renderer)) continue
 
-        const thingId = thing['@iot.id'] || thing.iotId || ''
+        const thingId = rawThing['@iot.id'] || rawThing.iotId || ''
         const locationId = location['@iot.id'] || ''
         const point = props.getPoint(location.location)
         const isFc = props.isFeatureCollection(location.location)
@@ -113,12 +120,16 @@ const matchedItems = computed(() => {
 
         const thingDatastreams = thing.datastreams ?? []
         for (const datastream of thingDatastreams) {
-          const dsId = (datastream as BoxedDatastream).iotId || ''
+          // Track the reactive observations reference so observation merges
+          // still retrigger this computed (see db4d3512).
+          void (datastream as any).observations
+          const rawDs = toRaw(datastream) as BoxedDatastream
+          const dsId = rawDs.iotId || ''
           for (const subrenderer of renderer.ds_renderer) {
-            if (!props.compareDatastream(datastream as BoxedDatastream, subrenderer)) continue
+            if (!props.compareDatastream(rawDs, subrenderer)) continue
 
-            const observedAreaGeoJson = datastream.observedArea
-              ? props.transformToGeoJson(datastream.observedArea)
+            const observedAreaGeoJson = (rawDs as any).observedArea
+              ? props.transformToGeoJson((rawDs as any).observedArea)
               : null
 
             const dsPoint = subrenderer.placement === ERefType.Thing
@@ -320,11 +331,26 @@ const isThingSelected = (thing: any): boolean => {
 // Get highlight color with default
 const highlightColor = computed(() => props.selectionHighlightColor || '#ff0000')
 
+// Whether any renderer actually uses zoom-dependent features. If none do,
+// effectiveZoom stays constant so zooming/panning never re-renders the
+// (potentially hundreds of) markers — Leaflet moves them via CSS on its own.
+const usesZoomSettings = (s: any): boolean =>
+  s != null && (s.iconMinZoom != null || s.iconScaleWithZoom || s.labelMinZoom != null ||
+    s.labelScaleWithZoom || s.clusterEnabled)
+
+const zoomFeaturesActive = computed(() =>
+  props.renderers.some((r: any) =>
+    usesZoomSettings(r.renderer) || (r.ds_renderer ?? []).some((d: any) => usesZoomSettings(d.renderer))
+  )
+)
+
+const effectiveZoom = computed(() => zoomFeaturesActive.value ? (props.currentZoom ?? 99) : 99)
+
 // Zoom-based visibility and scaling for icons
 const isIconVisible = (renderer: any): boolean => {
   const settings = renderer.renderer
   if (settings?.iconMinZoom == null) return true
-  return (props.currentZoom ?? 99) >= settings.iconMinZoom
+  return effectiveZoom.value >= settings.iconMinZoom
 }
 
 const getIconScale = (renderer: any): number => {
@@ -340,7 +366,7 @@ const getIconScale = (renderer: any): number => {
 const isLabelVisible = (renderer: any): boolean => {
   const settings = renderer.renderer
   if (settings?.labelMinZoom == null) return true
-  return (props.currentZoom ?? 99) >= settings.labelMinZoom
+  return effectiveZoom.value >= settings.labelMinZoom
 }
 
 const getLabelScale = (renderer: any): number => {
@@ -357,7 +383,7 @@ const shouldCluster = (renderer: any): boolean => {
   const settings = renderer.renderer
   if (!settings?.clusterEnabled) return false
   const clusterBelow = settings.clusterBelowZoom ?? 14
-  return (props.currentZoom ?? 99) < clusterBelow
+  return effectiveZoom.value < clusterBelow
 }
 
 // Grid-based clustering: divides the map into cells of clusterRadius pixels.
@@ -376,23 +402,29 @@ const gridCluster = <T extends { point: any; renderer: any }>(
   }> = []
   const unclustered: T[] = []
 
-  // Group by renderer id
-  const byRenderer = new Map<string, T[]>()
+  // Group items that should cluster. Per renderer by default; with
+  // clusterGlobal all cluster-enabled renderers share one group so nearby
+  // markers of different renderers merge into a single cluster.
+  const byGroup = new Map<string, T[]>()
   for (const item of items) {
     if (!item.point) continue
-    const rid = item.renderer.id ?? 'default'
-    if (!byRenderer.has(rid)) byRenderer.set(rid, [])
-    byRenderer.get(rid)!.push(item)
-  }
-
-  for (const [rid, rendererItems] of byRenderer) {
-    const renderer = rendererItems[0].renderer
-    if (!shouldCluster(renderer)) {
-      unclustered.push(...rendererItems)
+    if (!shouldCluster(item.renderer)) {
+      unclustered.push(item)
       continue
     }
+    const gid = props.clusterGlobal ? '__global__' : (item.renderer.id ?? 'default')
+    if (!byGroup.has(gid)) byGroup.set(gid, [])
+    byGroup.get(gid)!.push(item)
+  }
 
-    const radiusPx = renderer.renderer?.clusterRadius ?? 40
+  for (const [rid, rendererItems] of byGroup) {
+    const renderer = rendererItems[0].renderer
+
+    // Global group: largest configured radius wins so the merge is at least
+    // as aggressive as each participating renderer expects.
+    const radiusPx = props.clusterGlobal
+      ? Math.max(...rendererItems.map(g => g.renderer.renderer?.clusterRadius ?? 40))
+      : (renderer.renderer?.clusterRadius ?? 40)
     const zoom = props.currentZoom ?? 14
     // Grid cell size in degrees: convert pixel radius to degrees at current zoom
     const metersPerPixel = 156543.03 / Math.pow(2, zoom)
@@ -417,11 +449,25 @@ const gridCluster = <T extends { point: any; renderer: any }>(
           sumLat += g.point[0]
           sumLng += g.point[1]
         }
+        // The cluster is styled after the renderer contributing the most
+        // markers, so global clusters look like per-renderer ones unless
+        // they genuinely mix renderers — then the majority wins.
+        let clusterRenderer = renderer
+        if (props.clusterGlobal) {
+          const countByRenderer = new Map<any, number>()
+          for (const g of cellItems) {
+            countByRenderer.set(g.renderer, (countByRenderer.get(g.renderer) ?? 0) + 1)
+          }
+          let best = 0
+          for (const [r, n] of countByRenderer) {
+            if (n > best) { best = n; clusterRenderer = r }
+          }
+        }
         clusters.push({
           key: `${keyPrefix}-${rid}-${cellKey}`,
           point: [sumLat / cellItems.length, sumLng / cellItems.length],
           count: cellItems.length,
-          renderer,
+          renderer: clusterRenderer,
           items: cellItems,
         })
       }
@@ -441,19 +487,54 @@ const clusteredThings = computed(() =>
 const clusteredDatastreams = computed(() =>
   gridCluster(matchedItems.value.datastreams.filter(i => i.showMarker), 'ds-cluster')
 )
+
+// Areas belong to a location/observedArea, not to a thing or renderer. Emit each
+// unique geometry once instead of once per (renderer × thing [× datastream × ds_renderer]),
+// which previously stacked dozens of identical polygons on top of each other.
+const thingAreas = computed(() => {
+  const seen = new Map<string, any>()
+  for (const item of matchedItems.value.things) {
+    if (!item.isArea || !item.geoJson) continue
+    const locId = item.location['@iot.id'] || item.location.iotId || item.key
+    if (!seen.has(locId)) {
+      seen.set(locId, {
+        key: `area-${locId}`,
+        geojson: item.location.location,
+        area: item.renderer.renderer.area,
+        selected: false,
+      })
+    }
+    // an area counts as selected if ANY thing on it is selected
+    if (isThingSelected(item.thing)) seen.get(locId)!.selected = true
+  }
+  return [...seen.values()]
+})
+
+const datastreamAreas = computed(() => {
+  const seen = new Map<string, any>()
+  for (const item of matchedItems.value.datastreams) {
+    if (!item.observedAreaGeoJson) continue
+    const dsId = item.datastream.iotId || (item.datastream as any)['@iot.id'] || item.key
+    if (seen.has(dsId)) continue
+    seen.set(dsId, {
+      key: `dsarea-${dsId}`,
+      geojson: item.observedAreaGeoJson,
+      area: item.subrenderer.renderer.area,
+    })
+  }
+  return [...seen.values()]
+})
 </script>
 
 <template>
-  <!-- Thing markers/areas - flat list, no nested loops -->
-  <template v-for="item in matchedItems.things" :key="item.key + 'area'">
+  <!-- Thing areas — one <l-geo-json> per unique location geometry -->
+  <template v-for="area in thingAreas" :key="area.key">
     <l-geo-json
-      v-if="item.isArea"
-      ref="thingsLayer"
-      :geojson="item.location.location"
+      :geojson="area.geojson"
       :options="layerOptions"
-      :options-style="() => isThingSelected(item.thing)
-        ? { ...item.renderer.renderer.area, fillColor: highlightColor, color: highlightColor, fillOpacity: 0.5, weight: 3 }
-        : item.renderer.renderer.area as any"
+      :options-style="() => area.selected
+        ? { ...area.area, fillColor: highlightColor, color: highlightColor, fillOpacity: 0.5, weight: 3 }
+        : area.area as any"
     />
   </template>
 
@@ -512,14 +593,12 @@ const clusteredDatastreams = computed(() =>
     </l-marker>
   </template>
 
-  <!-- Datastream areas -->
-  <template v-for="item in matchedItems.datastreams" :key="item.key + 'dsarea'">
+  <!-- Datastream areas — one per unique observedArea -->
+  <template v-for="area in datastreamAreas" :key="area.key">
     <l-geo-json
-      v-if="item.observedAreaGeoJson"
-      ref="thingsLayer"
-      :geojson="item.observedAreaGeoJson"
+      :geojson="area.geojson"
       :options="{ ...layerOptions, pane: areaPane || 'overlayPane' }"
-      :options-style="()=>item.subrenderer.renderer.area as any"
+      :options-style="() => area.area as any"
     />
   </template>
 

--- a/packages/ui/vue/widget/map/src/components/OGCSTALayer.vue
+++ b/packages/ui/vue/widget/map/src/components/OGCSTALayer.vue
@@ -9,7 +9,7 @@ Contributors: Smart City Jena
 
 -->
 <script lang="ts" setup>
-import { ref, watch, computed, type Ref } from 'vue'
+import { ref, computed, onErrorCaptured, type Ref } from 'vue'
 import { LGeoJson, LMarker, LIcon, LTooltip } from '@vue-leaflet/vue-leaflet'
 import { type BoxedDatastream } from 'org.eclipse.daanse.board.app.lib.datasource.ogcsta'
 import L from 'leaflet'
@@ -43,10 +43,24 @@ interface OGCSTALayerProps {
   selectionHighlightColor?: string
   tooltipThingId?: string | null
   tooltipContent?: string | null
+  currentZoom?: number
 }
 
 const props = defineProps<OGCSTALayerProps>()
 const openThing = ref<{ [key: string]: boolean }>({})
+
+// Safety net for a known vue-leaflet (0.10.1) teardown race: when markers are
+// unmounted during cluster/zoom transitions, Leaflet's removeLayer can touch an
+// already-detached layer and throw `_leaflet_id`. It is harmless (the layer is
+// going away anyway), but must be caught so it doesn't tear down the marker layer.
+// We log it instead of swallowing it silently, and let every other error propagate.
+// TODO: re-evaluate removing this once verified in-app that reduced churn no longer triggers it.
+onErrorCaptured((err) => {
+  if (err instanceof TypeError && err.message.includes('_leaflet_id')) {
+    log('suppressed known vue-leaflet teardown race: %s', err.message)
+    return false
+  }
+})
 
 const eventBus = container.get<TinyEmitter>(identifiers.TINY_EMITTER)
 
@@ -305,6 +319,128 @@ const isThingSelected = (thing: any): boolean => {
 
 // Get highlight color with default
 const highlightColor = computed(() => props.selectionHighlightColor || '#ff0000')
+
+// Zoom-based visibility and scaling for icons
+const isIconVisible = (renderer: any): boolean => {
+  const settings = renderer.renderer
+  if (settings?.iconMinZoom == null) return true
+  return (props.currentZoom ?? 99) >= settings.iconMinZoom
+}
+
+const getIconScale = (renderer: any): number => {
+  const settings = renderer.renderer
+  if (!settings?.iconScaleWithZoom) return 1
+  const fullSizeZoom = settings.iconFullSizeZoom ?? 18
+  const zoom = props.currentZoom ?? fullSizeZoom
+  if (zoom >= fullSizeZoom) return 1
+  return Math.max(0.2, zoom / fullSizeZoom)
+}
+
+// Zoom-based visibility and scaling for labels
+const isLabelVisible = (renderer: any): boolean => {
+  const settings = renderer.renderer
+  if (settings?.labelMinZoom == null) return true
+  return (props.currentZoom ?? 99) >= settings.labelMinZoom
+}
+
+const getLabelScale = (renderer: any): number => {
+  const settings = renderer.renderer
+  if (!settings?.labelScaleWithZoom) return 1
+  const fullSizeZoom = settings.labelFullSizeZoom ?? 18
+  const zoom = props.currentZoom ?? fullSizeZoom
+  if (zoom >= fullSizeZoom) return 1
+  return Math.max(0.2, zoom / fullSizeZoom)
+}
+
+// Clustering: should this renderer cluster at current zoom?
+const shouldCluster = (renderer: any): boolean => {
+  const settings = renderer.renderer
+  if (!settings?.clusterEnabled) return false
+  const clusterBelow = settings.clusterBelowZoom ?? 14
+  return (props.currentZoom ?? 99) < clusterBelow
+}
+
+// Grid-based clustering: divides the map into cells of clusterRadius pixels.
+// Each cell that contains more than one marker becomes a cluster.
+// This prevents the greedy "chain" effect where distant markers get lumped together.
+const gridCluster = <T extends { point: any; renderer: any }>(
+  items: T[],
+  keyPrefix: string
+) => {
+  const clusters: Array<{
+    key: string
+    point: any
+    count: number
+    renderer: any
+    items: T[]
+  }> = []
+  const unclustered: T[] = []
+
+  // Group by renderer id
+  const byRenderer = new Map<string, T[]>()
+  for (const item of items) {
+    if (!item.point) continue
+    const rid = item.renderer.id ?? 'default'
+    if (!byRenderer.has(rid)) byRenderer.set(rid, [])
+    byRenderer.get(rid)!.push(item)
+  }
+
+  for (const [rid, rendererItems] of byRenderer) {
+    const renderer = rendererItems[0].renderer
+    if (!shouldCluster(renderer)) {
+      unclustered.push(...rendererItems)
+      continue
+    }
+
+    const radiusPx = renderer.renderer?.clusterRadius ?? 40
+    const zoom = props.currentZoom ?? 14
+    // Grid cell size in degrees: convert pixel radius to degrees at current zoom
+    const metersPerPixel = 156543.03 / Math.pow(2, zoom)
+    const cellSize = (radiusPx * metersPerPixel) / 111320
+
+    // Assign each item to a grid cell
+    const cells = new Map<string, T[]>()
+    for (const item of rendererItems) {
+      const cellX = Math.floor(item.point[1] / cellSize) // lng
+      const cellY = Math.floor(item.point[0] / cellSize) // lat
+      const cellKey = `${cellX},${cellY}`
+      if (!cells.has(cellKey)) cells.set(cellKey, [])
+      cells.get(cellKey)!.push(item)
+    }
+
+    for (const [cellKey, cellItems] of cells) {
+      if (cellItems.length === 1) {
+        unclustered.push(cellItems[0])
+      } else {
+        let sumLat = 0, sumLng = 0
+        for (const g of cellItems) {
+          sumLat += g.point[0]
+          sumLng += g.point[1]
+        }
+        clusters.push({
+          key: `${keyPrefix}-${rid}-${cellKey}`,
+          point: [sumLat / cellItems.length, sumLng / cellItems.length],
+          count: cellItems.length,
+          renderer,
+          items: cellItems,
+        })
+      }
+    }
+  }
+
+  return { clusters, unclustered }
+}
+
+// Grid-clustered marker sets, recomputed reactively. Vue's keyed diffing only
+// mounts/unmounts the markers whose keys actually change on a cluster/zoom
+// transition, so we avoid the mass destroy/create that used to trigger the
+// vue-leaflet removeLayer race (see onErrorCaptured above).
+const clusteredThings = computed(() =>
+  gridCluster(matchedItems.value.things, 'cluster')
+)
+const clusteredDatastreams = computed(() =>
+  gridCluster(matchedItems.value.datastreams.filter(i => i.showMarker), 'ds-cluster')
+)
 </script>
 
 <template>
@@ -321,9 +457,26 @@ const highlightColor = computed(() => props.selectionHighlightColor || '#ff0000'
     />
   </template>
 
-  <template v-for="item in matchedItems.things" :key="item.key + 'marker'">
+  <!-- Thing cluster markers -->
+  <template v-for="cluster in clusteredThings.clusters" :key="cluster.key">
     <l-marker
-      v-if="item.point"
+      v-if="isIconVisible(cluster.renderer)"
+      :lat-lng="cluster.point as L.LatLngExpression"
+      :options="{ pane: markerPane }"
+    >
+      <l-icon class-name="someExtraClass">
+        <div class="cluster-marker" :style="{ background: cluster.renderer.renderer.pointPin?.color || '#3388ff' }">
+          {{ cluster.count }}
+        </div>
+      </l-icon>
+      <l-tooltip>{{ cluster.count }} items</l-tooltip>
+    </l-marker>
+  </template>
+
+  <!-- Unclustered thing markers -->
+  <template v-for="item in clusteredThings.unclustered" :key="item.key + 'marker'">
+    <l-marker
+      v-if="item.point && isIconVisible(item.renderer)"
       :lat-lng="item.point as L.LatLngExpression"
       :options="{ pane: markerPane }"
       @click="handleThingClick(item.thing, item.location, item.renderer)"
@@ -340,15 +493,22 @@ const highlightColor = computed(() => props.selectionHighlightColor || '#ff0000'
           :is-solid="item.renderer.renderer.pointPin?.solid"
           :is-selected="isThingSelected(item.thing)"
           :selection-color="highlightColor"
+          :scale="getIconScale(item.renderer)"
         />
       </l-icon>
       <l-tooltip
+        v-if="isLabelVisible(item.renderer)"
         :options="{
           permanent: isActionTooltipVisible(item.thing),
           direction: 'top',
           offset: [0, -20]
         }"
-      >{{ getActionTooltipContent(item.thing) || getThingTooltip(item.thing) }}</l-tooltip>
+      >
+        <span v-if="getLabelScale(item.renderer) !== 1" :style="{ transform: `scale(${getLabelScale(item.renderer)})`, display: 'inline-block', transformOrigin: 'center' }">
+          {{ getActionTooltipContent(item.thing) || getThingTooltip(item.thing) }}
+        </span>
+        <template v-else>{{ getActionTooltipContent(item.thing) || getThingTooltip(item.thing) }}</template>
+      </l-tooltip>
     </l-marker>
   </template>
 
@@ -382,16 +542,37 @@ const highlightColor = computed(() => props.selectionHighlightColor || '#ff0000'
     </template>
   </template>
 
-  <!-- Datastream markers -->
-  <template v-for="item in matchedItems.datastreams" :key="item.key + 'dsmarker'">
+  <!-- Datastream cluster markers -->
+  <template v-for="cluster in clusteredDatastreams.clusters" :key="cluster.key">
     <l-marker
-      v-if="item.showMarker"
+      v-if="isIconVisible(cluster.renderer)"
+      :lat-lng="cluster.point as L.LatLngExpression"
+      :options="{ pane: markerPane }"
+    >
+      <l-icon class-name="someExtraClass">
+        <div class="cluster-marker" :style="{ background: cluster.renderer.renderer.pointPin?.color || '#3388ff' }">
+          {{ cluster.count }}
+        </div>
+      </l-icon>
+      <l-tooltip>{{ cluster.count }} items</l-tooltip>
+    </l-marker>
+  </template>
+
+  <!-- Unclustered datastream markers -->
+  <template v-for="item in clusteredDatastreams.unclustered" :key="item.key + 'dsmarker'">
+    <l-marker
+      v-if="item.showMarker && isIconVisible(item.renderer)"
       :lat-lng="item.point as L.LatLngExpression"
       :options="{ pane: markerPane }"
       @click="handleDatastreamMarkerClick(item.datastream as BoxedDatastream, item.thing, item.subrenderer)"
       @mouseenter="handleDatastreamHover(item.datastream as BoxedDatastream, item.thing)"
     >
-      <l-tooltip>{{ getDatastreamTooltip(item.datastream, item.thing) }}</l-tooltip>
+      <l-tooltip v-if="isLabelVisible(item.renderer)">
+        <span v-if="getLabelScale(item.renderer) !== 1" :style="{ transform: `scale(${getLabelScale(item.renderer)})`, display: 'inline-block', transformOrigin: 'center' }">
+          {{ getDatastreamTooltip(item.datastream, item.thing) }}
+        </span>
+        <template v-else>{{ getDatastreamTooltip(item.datastream, item.thing) }}</template>
+      </l-tooltip>
       <l-icon class-name="someExtraClass">
         <MapMarker
           :render-as="item.subrenderer.renderer.point_render_as"
@@ -404,6 +585,7 @@ const highlightColor = computed(() => props.selectionHighlightColor || '#ff0000'
           :is-round="true"
           :is-selected="isThingSelected(item.thing)"
           :selection-color="highlightColor"
+          :scale="getIconScale(item.renderer)"
         >
           <template #observation>
             <template v-if="item.datastream.observations">
@@ -424,3 +606,21 @@ const highlightColor = computed(() => props.selectionHighlightColor || '#ff0000'
     </l-marker>
   </template>
 </template>
+
+<style scoped>
+.cluster-marker {
+  min-width: 32px;
+  min-height: 32px;
+  padding: 4px;
+  border-radius: 50%;
+  color: #fff;
+  font-weight: bold;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  border: 3px solid rgba(255, 255, 255, 0.8);
+  transform: translate(-50%, -50%);
+}
+</style>

--- a/packages/ui/vue/widget/map/src/gen/MapSettings.ts
+++ b/packages/ui/vue/widget/map/src/gen/MapSettings.ts
@@ -60,6 +60,9 @@ export class MapSettings {
   @Documentation("Enable marker clustering for OGC STA Things and Datastreams")
   @Attribute() enableClustering?: boolean;
 
+  @Documentation("Cluster markers of all renderers into shared clusters instead of one cluster set per renderer. Only applies to renderers that have clustering enabled.")
+  @Attribute() clusterGlobal?: boolean;
+
   @Documentation("Color used to highlight selected Things on the map (default: #ff0000)")
   @Attribute() selectionHighlightColor: string = "#ff0000";
 

--- a/packages/ui/vue/widget/map/src/gen/PointAndAreaSettings.ts
+++ b/packages/ui/vue/widget/map/src/gen/PointAndAreaSettings.ts
@@ -45,4 +45,31 @@ export class PointAndAreaSettings {
 
   @Documentation("Optional settings for labels. (Mapped from TypeScript 'any' type).")
   @Attribute() label?: any;
+
+  @Documentation("Minimum zoom level at which icons are visible. Below this zoom level, icons are hidden.")
+  @Attribute() iconMinZoom?: number;
+
+  @Documentation("Enable scaling of icons based on zoom level. Icons shrink when zooming out.")
+  @Attribute() iconScaleWithZoom?: boolean;
+
+  @Documentation("The zoom level at which icons are rendered at full size (scale=1). Below this, icons shrink proportionally.")
+  @Attribute() iconFullSizeZoom?: number;
+
+  @Documentation("Minimum zoom level at which labels/tooltips are visible. Below this zoom level, labels are hidden.")
+  @Attribute() labelMinZoom?: number;
+
+  @Documentation("Enable scaling of labels based on zoom level. Labels shrink when zooming out.")
+  @Attribute() labelScaleWithZoom?: boolean;
+
+  @Documentation("The zoom level at which labels are rendered at full size (scale=1). Below this, labels shrink proportionally.")
+  @Attribute() labelFullSizeZoom?: number;
+
+  @Documentation("Enable clustering of markers when zoomed out. Below clusterBelowZoom, nearby markers are grouped into a single marker showing the count.")
+  @Attribute() clusterEnabled?: boolean;
+
+  @Documentation("Zoom level below which markers are clustered. At and above this zoom level, individual markers are shown.")
+  @Attribute() clusterBelowZoom?: number;
+
+  @Documentation("Pixel radius used to group nearby markers into a cluster.")
+  @Attribute() clusterRadius?: number;
 }

--- a/packages/ui/vue/widget/map/src/parts/styler/PointStyler.vue
+++ b/packages/ui/vue/widget/map/src/parts/styler/PointStyler.vue
@@ -117,6 +117,66 @@ const pointSelectorOptions = [
         label="Solid (vollflächig)"
       />
     </template>
+
+    <VaDivider class="mb15" />
+    <h4 class="va-title">Zoom Visibility</h4>
+
+    <VaInput
+      v-model.number="model.iconMinZoom"
+      type="number"
+      label="Icon min. Zoom"
+      placeholder="e.g. 12"
+    />
+    <VaCheckbox
+      v-model="model.iconScaleWithZoom"
+      label="Scale icons with zoom"
+    />
+    <VaInput
+      v-if="model.iconScaleWithZoom"
+      v-model.number="model.iconFullSizeZoom"
+      type="number"
+      label="Icon full size at zoom"
+      placeholder="e.g. 18"
+    />
+    <VaInput
+      v-model.number="model.labelMinZoom"
+      type="number"
+      label="Label min. Zoom"
+      placeholder="e.g. 14"
+    />
+    <VaCheckbox
+      v-model="model.labelScaleWithZoom"
+      label="Scale labels with zoom"
+    />
+    <VaInput
+      v-if="model.labelScaleWithZoom"
+      v-model.number="model.labelFullSizeZoom"
+      type="number"
+      label="Label full size at zoom"
+      placeholder="e.g. 18"
+    />
+
+    <VaDivider class="mb15" />
+    <h4 class="va-title">Clustering</h4>
+
+    <VaCheckbox
+      v-model="model.clusterEnabled"
+      label="Cluster markers when zoomed out"
+    />
+    <template v-if="model.clusterEnabled">
+      <VaInput
+        v-model.number="model.clusterBelowZoom"
+        type="number"
+        label="Cluster below zoom"
+        placeholder="e.g. 14"
+      />
+      <VaInput
+        v-model.number="model.clusterRadius"
+        type="number"
+        label="Cluster radius (px)"
+        placeholder="e.g. 40"
+      />
+    </template>
   </div>
   <div class="flex flex-col md6 pa-3">
     <MapPreviewPoint ref="MapPrev2" v-bind="model.point">

--- a/packages/ui/vue/widget/map/src/utils/helpers.ts
+++ b/packages/ui/vue/widget/map/src/utils/helpers.ts
@@ -75,20 +75,29 @@ export function resolve(start: any, ...args: (string | number)[]) {
   }, start)
 }
 
-export function resolveObj(obj: any, dotNotatedstring: string) {
-  const replace = dotNotatedstring.replace('\\.', '<|>')
-  try {
-    return replace.split('.').reduce((o, i) => {
-      const aNumber = parseInt(i)
-      if (isFinite(aNumber) && Array.isArray(o)) {
-        return o[aNumber]
-      }
-      return o[i.replace('<|>', '.')]
-    }, obj)
-  } catch (e) {
-    return null
-  }
+// resolveObj runs tens of thousands of times per map recompute (once per
+// condition per datastream), so the parsed key path is cached instead of
+// doing replace/split/parseInt on every call.
+const resolvePathCache = new Map<string, string[]>()
 
+export function resolveObj(obj: any, dotNotatedstring: string) {
+  let keys = resolvePathCache.get(dotNotatedstring)
+  if (!keys) {
+    keys = dotNotatedstring.replace('\\.', '<|>').split('.')
+      .map(k => k.replace('<|>', '.'))
+    resolvePathCache.set(dotNotatedstring, keys)
+  }
+  let o = obj
+  for (const k of keys) {
+    if (o == null) return null
+    if (Array.isArray(o)) {
+      const aNumber = parseInt(k)
+      o = isFinite(aNumber) ? o[aNumber] : o[k as keyof typeof o]
+    } else {
+      o = o[k]
+    }
+  }
+  return o
 }
 
 


### PR DESCRIPTION
## Summary

### Map widget
- **Zoom-scaled icons & labels**: per-renderer `iconMinZoom` / `iconScaleWithZoom` / `labelMinZoom` / `labelScaleWithZoom` settings — icons and labels can hide or shrink when zooming out.
- **Marker clustering**: grid-based clustering below a configurable zoom (`clusterEnabled` / `clusterBelowZoom` / `clusterRadius`), plus a new map-level option **"Cluster markers across renderers"** (`clusterGlobal`) that merges cluster-enabled renderers into shared clusters (majority renderer's pin color styles the cluster).
- **Area dedup fix**: each OGC-STA area is rendered once instead of per renderer/thing(×datastream×ds_renderer) — identical polygons were stacked dozens of times (186→26 SVG paths on the test board). ⚠️ Boards whose area colors relied on the alpha-stacking of duplicates need stronger fill colors.
- **Zoom/pan performance**: renderer condition matching now runs on raw objects instead of Vue proxies (>1.2 s tasks per zoom before; 51k→5k profile samples for `compareDatastream`), `resolveObj` caches parsed key paths, and zooming no longer re-renders markers when no renderer uses zoom-dependent features. Reactivity on observation merges is preserved.

### OGC-STA datasource
- **Cache merge dedup**: every filter/refresh cycle blindly concatenated the full result set into the cache, multiplying every location/thing/datastream (6× after six cycles) — inflating cluster counts, duplicate v-for keys and loop work everywhere downstream.

### Chart widget
- **Per-series value formula**: new optional "Value formula" field, e.g. `(value - 32) * 5 / 9` converts °F→°C. Compiled once per dataset, supports plain numbers and `{x,y}` points, invalid formulas leave data untouched.

### SaveLoad
- **Upload fix**: uploaded board files were read but never loaded; double-encoded downloads and boards without connections/datasources are now handled.

## Test notes
- Verified live against `udp.datainmotion.com` STA data (bodenfeuchte board): cluster counts now match real sensor counts, areas render once, zoom/pan traces show the background load dropping from ~23% to ~3% CPU.
- `vue-tsc --noEmit` and `vite build` green for the map and chart packages.