### PR TITLE
fix: use named import for octokit-commit-multiple-files plugin

### DIFF
--- a/packages/lib/persistence/git/src/git_api/services/github/CommitProvider.ts
+++ b/packages/lib/persistence/git/src/git_api/services/github/CommitProvider.ts
@@ -15,7 +15,7 @@ import Commit from '../../services/common/Commit'
 import type { FileProviderI } from '../../api/FileProvider'
 import type { FileI } from '../../api/File'
 import type { BranchI } from '../../api/Branch'
-import OktokitMultipleFiles from 'octokit-commit-multiple-files'
+import { CreateOrUpdateFiles } from 'octokit-commit-multiple-files'
 import type { FolderI } from '../../api/Folder'
 import { FileState } from '../../api/FileState'
 import { AuthentificationError } from '../common/CastError'
@@ -35,7 +35,7 @@ export default class CommitProvider implements CommitProviderI {
     this.owner = owner
     this.name = name
     this.options = options
-    const oc = Octokit.plugin(OktokitMultipleFiles as unknown as OctokitPlugin)
+    const oc = Octokit.plugin(CreateOrUpdateFiles as unknown as OctokitPlugin)
     this._oc = new oc(this.options)
   }
 
@@ -116,7 +116,7 @@ export default class CommitProvider implements CommitProviderI {
 
   setOptions(options: any) {
     this.options = options
-    const oc = Octokit.plugin(OktokitMultipleFiles as unknown as OctokitPlugin)
+    const oc = Octokit.plugin(CreateOrUpdateFiles as unknown as OctokitPlugin)
     this._oc = new oc(this.options)
   }
 

--- a/packages/lib/persistence/git/src/git_api/types/octokit-comit-multiple-files.d.ts
+++ b/packages/lib/persistence/git/src/git_api/types/octokit-comit-multiple-files.d.ts
@@ -7,23 +7,7 @@
   Contributors: Smart City Jena
 */
 declare module 'octokit-commit-multiple-files' {
-  import { Octokit } from '@octokit/core'
+  import type { OctokitPlugin } from '@octokit/core/dist-types/types'
 
-  interface CommitFile {
-    path: string;
-    content: string;
-  }
-
-  interface CommitOptions {
-    owner: string;
-    repo: string;
-    message: string;
-    files: CommitFile[];
-    branch?: string;
-  }
-
-  export function commitMultipleFiles(
-    octokit: Octokit,
-    options: CommitOptions
-  ): Promise<any>;
+  export const CreateOrUpdateFiles: OctokitPlugin;
 }


### PR DESCRIPTION
## Summary

`octokit-commit-multiple-files` exports `CreateOrUpdateFiles` as a **named** export, not a default export. The incorrect default import caused `Octokit.plugin()` to fail, preventing **GitHub repositories from being registered** as persistence backends (visible as an uncaught promise rejection right after "found owner for git repo" during startup).

- Use the named import in `CommitProvider.ts` (both constructor and `setOptions`)
- Align the module declaration in `octokit-comit-multiple-files.d.ts` accordingly

Cherry-picked from `feat/undo-redo-editor` so the fix can land independently of the undo/redo feature.